### PR TITLE
Add Kaggle dataset link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Access the D-Fire dataset, including images, annotations, and pre-split training
 
 * [D-Fire dataset (only images and labels)](https://1drv.ms/u/c/c0bd25b6b048b01d/EbLgD7bES4FDvUN37Grxn8QBF5gIBBc7YV2qklF08GCiBw).
 * [Training, validation and test sets](https://1drv.ms/f/c/c0bd25b6b048b01d/Ema8FFze8mFIlM1Hn81BUUgBE3vnnmK4SQxybS-nHRt2pA?e=6rk0aN).
+* [Kaggle version ready to use](https://www.kaggle.com/datasets/sayedgamal99/smoke-fire-detection-yolo).
 * [Some surveillance videos](https://1drv.ms/f/c/c0bd25b6b048b01d/EhT2Jy6L-YlGvZv-gXH2SnYBENQsnUW96LpZtv_6PngjYQ). 
 * [Some deep learning models trained with the D-Fire dataset](https://github.com/pedbrgs/Fire-Detection).
 * For more surveillance videos, request your registration on our environmental monitoring platform ["Apaga o Fogo!" (Put out the Fire!)](https://apagaofogo.eco.br/).


### PR DESCRIPTION
This pull request adds a new resource link to the README.md to improve accessibility of the D-Fire dataset.

I collected the dataset from the original drive and prepared a Kaggle-ready version for easier use and testing, with proper citation and attribution to the original authors. The dataset has been well-received by the community and is now readily available on Kaggle.

Dataset accessibility improvements

Added a link to a Kaggle-ready version of the D-Fire dataset, providing users with a convenient and widely used platform for downloading and experimenting with the data.